### PR TITLE
allow private base without key ref or with extra comment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /app
 
 
 RUN go test -v -cover ./... \
-    && go build -o /argocd-voodoobox-plugin .
+    && go build -ldflags='-s -w' -o /argocd-voodoobox-plugin .
 
 # final stage
 # argocd requires that sidecar container is running as user 999

--- a/git-ssh.go
+++ b/git-ssh.go
@@ -167,8 +167,7 @@ func updateRepoBaseAddresses(in io.Reader) (map[string]string, []byte, error) {
 		case keyName != "" && !reRepoAddressWithSSH.MatchString(l):
 			return nil, nil, fmt.Errorf("found key reference in comment but next remote base url doesn't contain ssh://")
 
-		// referencing key is not mandatory since only 1 ssh key
-		//  can be sued for all private base
+		// referencing key is not mandatory since only 1 key can be used for all private base
 		// case keyName == "" && reRepoAddressWithSSH.MatchString(l):
 		// 	return nil, nil, fmt.Errorf("found remote base url with ssh protocol without referenced key comment above")
 

--- a/git-ssh.go
+++ b/git-ssh.go
@@ -28,7 +28,7 @@ const (
 )
 
 var (
-	reKeyName            = regexp.MustCompile(`#\s*?argocd-voodoobox-plugin:\s*?(?P<keyName>\w+)`)
+	reKeyName            = regexp.MustCompile(`#.*?argocd-voodoobox-plugin:\s*?(?P<keyName>\w+)`)
 	reRepoAddressWithSSH = regexp.MustCompile(`(?P<beginning>^\s*-\s*ssh:\/\/)(?P<domain>\w.+?)(?P<repoDetails>\/.*$)`)
 )
 
@@ -167,8 +167,10 @@ func updateRepoBaseAddresses(in io.Reader) (map[string]string, []byte, error) {
 		case keyName != "" && !reRepoAddressWithSSH.MatchString(l):
 			return nil, nil, fmt.Errorf("found key reference in comment but next remote base url doesn't contain ssh://")
 
-		case keyName == "" && reRepoAddressWithSSH.MatchString(l):
-			return nil, nil, fmt.Errorf("found remote base url with ssh protocol without referenced key comment above")
+		// referencing key is not mandatory since only 1 ssh key
+		//  can be sued for all private base
+		// case keyName == "" && reRepoAddressWithSSH.MatchString(l):
+		// 	return nil, nil, fmt.Errorf("found remote base url with ssh protocol without referenced key comment above")
 
 		case keyName != "" && reRepoAddressWithSSH.MatchString(l):
 			// If Key if found replace domain


### PR DESCRIPTION
following config is now allowed,  if only 1 key is used for all private repo then there is no need to reference that key
```
  - github.com/org/open1//manifests/lab-foo?ref=master
  - ssh://github.com/org/repo3//manifests/lab-zoo?ref=dev
```

plugin will pick correct key `sshKeyB` from following config
```
  # some-extra comment : key_b argocd-voodoobox-plugin: sshKeyB
  - ssh://sshKeyB_gitlab_io/org/repo2//manifests/lab-bar?ref=main
```