### PR TITLE
make secret name static and check for ssh:// schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ resources:
 
  Plugin supports following _plugin envs_ which can be set in ArgoCD Application crd
 
-The value of name of a secret resource containing strongbox keyring used to encrypt app secrets, must be `argocd-strongbox-keyring`.
+The value of name of a secret resource containing strongbox keyring used to encrypt app secrets, must be `argocd-voodoobox-strongbox-keyring`.
 
 `STRONGBOX_SECRET_KEY` the value should be the name of the secret data key which contains a valid strongbox keyring file data. the default value is `.strongbox_keyring`
 
@@ -53,7 +53,7 @@ If this env is not specified then it defaults to the same namespace as the app's
 kind: Secret
 apiVersion: v1
 metadata:
-  name: argocd-strongbox-keyring
+  name: argocd-voodoobox-strongbox-keyring
   namespace: ns-a
   annotations:
     argocd.voodoobox.plugin.io/allowed-namespaces: "ns-b, ns-c"
@@ -133,7 +133,7 @@ data:
           - argocd-voodoobox-plugin
           - decrypt
         args:
-          - "--app-strongbox-secret-name=argocd-strongbox-keyring"
+          - "--app-strongbox-secret-name=argocd-voodoobox-strongbox-keyring"
           - "--secret-allowed-namespaces-annotation=argocd.voodoobox.plugin.io/allowed-namespaces"
       generate:
         command:
@@ -201,7 +201,7 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     resourceNames:
-      - argocd-strongbox-keyring
+      - argocd-voodoobox-strongbox-keyring
       - argocd-voodoobox-git-ssh
     verbs: ["get"]
 ---
@@ -229,7 +229,7 @@ subjects:
 | app arguments/ENVs | default | example / explanation |
 |-|-|-|
 | --secret-allowed-namespaces-annotation | argocd.voodoobox.plugin.io/allowed-namespaces | when shared secret is used this value is the annotation key to look for in secret to get comma-separated list of all the namespaces that are allowed to use it |
-| --app-strongbox-secret-name | argocd-strongbox-keyring | the value should be the name of a secret resource containing strongbox keyring used to encrypt app secrets. name will be same across all applications |
+| --app-strongbox-secret-name | argocd-voodoobox-strongbox-keyring | the value should be the name of a secret resource containing strongbox keyring used to encrypt app secrets. name will be same across all applications |
 | --app-git-ssh-secret-name | argocd-voodoobox-git-ssh | the value should be the name of a secret resource containing ssh keys used for fetching remote kustomize bases from private repositories. name will be same across all applications |
 | ARGOCD_APP_NAME | set by argocd | name of application |
 | ARGOCD_APP_NAMESPACE | set by argocd | application's destination namespace |

--- a/generate_test.go
+++ b/generate_test.go
@@ -12,8 +12,8 @@ func Test_hasSSHRemoteBaseURL(t *testing.T) {
 		want    bool
 		wantErr bool
 	}{
-		{"with remote bae", args{"./testData/app-with-remote-base"}, true, false},
-		{"without remote bae", args{"./testData/app-with-secrets"}, false, false},
+		{"with remote base", args{"./testData/app-with-remote-base"}, true, false},
+		{"without remote base", args{"./testData/app-with-secrets"}, false, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/generate_test.go
+++ b/generate_test.go
@@ -1,0 +1,35 @@
+package main
+
+import "testing"
+
+func Test_hasSSHRemoteBaseURL(t *testing.T) {
+	type args struct {
+		cwd string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{"with remote bae", args{"./testData/app-with-remote-base"}, true, false},
+		{"without remote bae", args{"./testData/app-with-secrets"}, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			files, err := findKustomizeFiles(tt.args.cwd)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := hasSSHRemoteBaseURL(files)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("hasSSHRemoteBaseURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("hasSSHRemoteBaseURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/git-ssh.go
+++ b/git-ssh.go
@@ -33,26 +33,16 @@ var (
 )
 
 func setupGitSSH(ctx context.Context, cwd string, app applicationInfo) (string, error) {
-	// Even when there is no git SSH secret defined, we still override the
-	// git ssh command (pointing the key to /dev/null) in order to avoid
-	// using ssh keys in default system locations and to surface the error
-	// if bases over ssh have been configured.
-	sshCmd := `GIT_SSH_COMMAND=ssh -q -F none -o IdentitiesOnly=yes -o IdentityFile=/dev/null -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no`
 	knownHostsFragment := `-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no`
-
-	// if ssh secret name is not set skip setup
-	if app.gitSSHSecret.name == "" {
-		return sshCmd, nil
-	}
 
 	sec, err := getSecret(ctx, app.destinationNamespace, app.gitSSHSecret)
 	if err != nil {
-		return sshCmd, fmt.Errorf("unable to get secret err:%v", err)
+		return "", fmt.Errorf("unable to get secret err:%v", err)
 	}
 
 	sshDir := filepath.Join(cwd, ".ssh")
 	if err := os.Mkdir(sshDir, 0700); err != nil {
-		return sshCmd, fmt.Errorf("unable to create ssh config dir err:%s", err)
+		return "", fmt.Errorf("unable to create ssh config dir err:%s", err)
 	}
 
 	// keyFilePaths holds key name and path values

--- a/git-ssh_test.go
+++ b/git-ssh_test.go
@@ -338,7 +338,7 @@ func Test_setupGitSSH(t *testing.T) {
 	kubeClient = fake.NewSimpleClientset(
 		&v1.Secret{
 			ObjectMeta: metaV1.ObjectMeta{
-				Name:      "argocd-git-ssh",
+				Name:      "argocd-voodoobox-git-ssh",
 				Namespace: "foo",
 			},
 			Data: map[string][]byte{
@@ -352,30 +352,28 @@ func Test_setupGitSSH(t *testing.T) {
 		},
 	)
 
-	noRemoteBase := applicationInfo{
+	withOutSecret := applicationInfo{
 		name:                 "app-foo",
-		destinationNamespace: "foo",
+		destinationNamespace: "foo-bar",
+		gitSSHSecret: secretInfo{
+			name: "argocd-voodoobox-git-ssh",
+		},
 	}
-
-	defaultEnv := "GIT_SSH_COMMAND=ssh -q -F none -o IdentitiesOnly=yes -o IdentityFile=/dev/null -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
-	env, err := setupGitSSH(context.Background(), withRemoteBaseTestDir, noRemoteBase)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if diff := cmp.Diff(defaultEnv, env); diff != "" {
-		t.Errorf("setupGitSSH()  mismatch (-want +got):\n%s", diff)
+	_, err := setupGitSSH(context.Background(), withRemoteBaseTestDir, withOutSecret)
+	if err == nil {
+		t.Fatal("expecting error here for missing secret from foo-bar NS")
 	}
 
 	app := applicationInfo{
 		name:                 "app-foo",
 		destinationNamespace: "foo",
 		gitSSHSecret: secretInfo{
-			name: "argocd-git-ssh",
+			name: "argocd-voodoobox-git-ssh",
 		},
 	}
 
 	wnatEnv := "GIT_SSH_COMMAND=ssh -q -F testData/app-with-remote-base-test1/.ssh/config -o UserKnownHostsFile=testData/app-with-remote-base-test1/.ssh/known_hosts"
-	env, err = setupGitSSH(context.Background(), withRemoteBaseTestDir, app)
+	env, err := setupGitSSH(context.Background(), withRemoteBaseTestDir, app)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func main() {
 						Value: ".strongbox_keyring",
 					},
 					// do not set `EnvVars` for secret name flag
-					// To keep service account's permission minimum name of the secret is static across ALL applications.
+					// To keep service account's permission minimum, the name of the secret is static across ALL applications.
 					// this value should only be set by admins of argocd as part of plugin setup
 					&cli.StringFlag{
 						Name: "app-strongbox-secret-name",
@@ -136,13 +136,13 @@ encrypt app secrets. name will be same across all applications`,
 	name of a namespace where secret resource containing ssh keys are located`,
 					},
 					// do not set `EnvVars` for secret name flag
-					// To keep service account's permission minimum name of the secret is static across ALL applications.
+					// To keep service account's permission minimum, the name of the secret is static across ALL applications.
 					// this value should only be set by admins of argocd as part of plugin setup
 					&cli.StringFlag{
 						Name: "app-git-ssh-secret-name",
 						Usage: `the value should be the name of a secret resource containing ssh keys used for 
 fetching remote kustomize bases from private repositories. name will be same across all applications`,
-						Value: "argocd-git-ssh",
+						Value: "argocd-voodoobox-git-ssh",
 					},
 					&cli.StringFlag{
 						Name: "secret-allowed-namespaces-annotation",

--- a/main.go
+++ b/main.go
@@ -75,18 +75,20 @@ func main() {
 	name of a namespace where secret resource containing strongbox keyring is located`,
 					},
 					&cli.StringFlag{
-						Name:    "app-strongbox-secret-name",
-						EnvVars: []string{argocdAppEnvPrefix + "STRONGBOX_SECRET_NAME"},
-						Usage: `set 'STRONGBOX_SECRET_NAME' in argocd application as plugin ENV. the value should be the
-	name of a secret resource containing strongbox keyring used to encrypt app secrets`,
-						Value: "argocd-strongbox-keyring",
-					},
-					&cli.StringFlag{
 						Name:    "app-strongbox-secret-key",
 						EnvVars: []string{argocdAppEnvPrefix + "STRONGBOX_SECRET_KEY"},
 						Usage: `set 'STRONGBOX_KEYRING_KEY' in argocd application as plugin ENV, the value should be the
 	name of the secret data key which contains a valid strongbox keyring file`,
 						Value: ".strongbox_keyring",
+					},
+					// do not set `EnvVars` for secret name flag
+					// To keep service account's permission minimum name of the secret is static across ALL applications.
+					// this value should only be set by admins of argocd as part of plugin setup
+					&cli.StringFlag{
+						Name: "app-strongbox-secret-name",
+						Usage: `the value should be the name of a secret resource containing strongbox keyring used to 
+encrypt app secrets. name will be same across all applications`,
+						Value: "argocd-strongbox-keyring",
 					},
 					&cli.StringFlag{
 						Name: "secret-allowed-namespaces-annotation",
@@ -133,11 +135,14 @@ func main() {
 						Usage: `set 'GIT_SSH_SECRET_NAMESPACE' in argocd application as plugin ENV. the value should be the
 	name of a namespace where secret resource containing ssh keys are located`,
 					},
+					// do not set `EnvVars` for secret name flag
+					// To keep service account's permission minimum name of the secret is static across ALL applications.
+					// this value should only be set by admins of argocd as part of plugin setup
 					&cli.StringFlag{
-						Name:    "app-git-ssh-secret-name",
-						EnvVars: []string{argocdAppEnvPrefix + "GIT_SSH_SECRET_NAME"},
-						Usage: `set 'GIT_SSH_SECRET_NAME' in argocd application as plugin ENV. the value should be the
-	name of a secret resource containing ssh keys used for fetching remote kustomize bases from private repositories`,
+						Name: "app-git-ssh-secret-name",
+						Usage: `the value should be the name of a secret resource containing ssh keys used for 
+fetching remote kustomize bases from private repositories. name will be same across all applications`,
+						Value: "argocd-git-ssh",
 					},
 					&cli.StringFlag{
 						Name: "secret-allowed-namespaces-annotation",

--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ func main() {
 						Name: "app-strongbox-secret-name",
 						Usage: `the value should be the name of a secret resource containing strongbox keyring used to 
 encrypt app secrets. name will be same across all applications`,
-						Value: "argocd-strongbox-keyring",
+						Value: "argocd-voodoobox-strongbox-keyring",
 					},
 					&cli.StringFlag{
 						Name: "secret-allowed-namespaces-annotation",


### PR DESCRIPTION
this PR is making secret name for strong box key and ssh keys  static to `argocd-strongbox-keyring` and `argocd-voodoobox-git-ssh` respectively. 